### PR TITLE
Add keyboard shortcut to open the Krunner with only this runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 # krunner-appmenu
 A KRunner plugin that shows the menu of the current application.
 
-To install, copy appmenurunner.desktop to ~/.local/share/kservices5/ and krunner_appmenu.py	to ~/.config/autostart-scripts/ and ensure it has executable permissions. It also depends on Python 3.4, dbus-python and python-xlib.
+To install
 
-(autostart-scripts is not ideal but it works)
+* Copy `appmenurunner.desktop` to `~/.local/share/kservices5/` 
+
+* Copy `krunner_appmenu.py` to `~/.config/autostart-scripts/` and ensure it has executable permissions. (autostart-scripts is not ideal but it works)
+
+* Copy `appmenurunner_globalshortcut.desktop` to `~/.local/share/kglobalaccel`. This will allow you to configure a keyboard shortcut that will launch krunner with only this runner enabled. By default, the shortcut is Meta+M.
+
+This plugin depends on Python 3.4, dbus-python and python-xlib.
+
+

--- a/appmenurunner_globalshortcut.desktop
+++ b/appmenurunner_globalshortcut.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Exec=/usr/bin/qdbus org.kde.krunner /App org.kde.krunner.App.displaySingleRunner appmenurunner
+Name=AppmenuRunner
+OnlyShowIn=KDE;
+Type=Application
+X-KDE-PluginInfo-Name=appmenurunner
+X-KDE-Shortcuts=Meta+M


### PR DESCRIPTION
Currently, I have set the default shortcut as Meta+M, but it can be configured in SystemSettings > Global Shortcuts > AppmenuRunner. This change adds another .desktop file which has to be copied to `./local/share/kglobalaccel`, and so I have also updated the README to mention this.

As mentioned in issue https://github.com/ArturGaspar/krunner-appmenu/issues/3#issuecomment-674564193, currently the filtering doesn't work because of a krunner bug which is fixed in the next version of krunner.